### PR TITLE
Removed godotenv for Heroku config

### DIFF
--- a/framework/config.go
+++ b/framework/config.go
@@ -4,8 +4,7 @@ import (
 	"log"
 	"os"
 	"strconv"
-
-	"github.com/joho/godotenv"
+	//"github.com/joho/godotenv"
 )
 
 type Config struct {
@@ -20,10 +19,10 @@ type Config struct {
 }
 
 func LoadConfig() *Config {
-	err := godotenv.Load()
-	if err != nil {
-		log.Fatal("Error loading .env file", err)
-	}
+	// err := godotenv.Load()
+	// if err != nil {
+	// 	log.Fatal("Error loading .env file", err)
+	// }
 
 	conf := new(Config)
 	conf.BotToken = os.Getenv("BOT_TOKEN")

--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,5 @@ go 1.13
 require (
 	github.com/Tnze/go-mc v1.15.1
 	github.com/bwmarrin/discordgo v0.20.3
-	github.com/joho/godotenv v1.3.0
+	//github.com/joho/godotenv v1.3.0
 )


### PR DESCRIPTION
- Removed godotenv to use Heroku config vars